### PR TITLE
Mark as non-resilient, reduce severity

### DIFF
--- a/health/healthcheck.go
+++ b/health/healthcheck.go
@@ -53,7 +53,7 @@ func (h *HealthCheck) whitelistCheck() fthealth.Check {
 	return fthealth.Check{
 		ID:               "message-whitelist",
 		Name:             "Message Whitelist Filter",
-		Severity:         1,
+		Severity:         2,
 		BusinessImpact:   "No metadata will be mapped to UPP. This will negatively impact metadata availability.",
 		TechnicalSummary: "The whitelist configuration for this mapper is invalid",
 		PanicGuide:       "https://dewey.ft.com/pac-annotations-mapper.html",
@@ -67,7 +67,7 @@ func (h *HealthCheck) readQueueCheck() fthealth.Check {
 	return fthealth.Check{
 		ID:               "read-message-queue-reachable",
 		Name:             "Read Message Queue Reachable",
-		Severity:         1,
+		Severity:         2,
 		BusinessImpact:   "PAC Metadata can't be read from queue. This will negatively impact metadata availability.",
 		TechnicalSummary: "Read message queue is not reachable/healthy",
 		PanicGuide:       "https://dewey.ft.com/pac-annotations-mapper.html",
@@ -79,7 +79,7 @@ func (h *HealthCheck) writeQueueCheck() fthealth.Check {
 	return fthealth.Check{
 		ID:               "write-message-queue-reachable",
 		Name:             "Write Message Queue Reachable",
-		Severity:         1,
+		Severity:         2,
 		BusinessImpact:   "Mapped Metadata can't be written to queue. This will negatively impact metadata availability.",
 		TechnicalSummary: "Write message queue is not reachable/healthy",
 		PanicGuide:       "https://dewey.ft.com/pac-annotations-mapper.html",

--- a/helm/pac-annotations-mapper/templates/service.yaml
+++ b/helm/pac-annotations-mapper/templates/service.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{.Values.service.name}}
     visualize: "true" 
     hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 
+    isResilient: "{{ .Values.service.isResilient }}"
 spec:
   ports: 
     - port: 8080 

--- a/helm/pac-annotations-mapper/values.yaml
+++ b/helm/pac-annotations-mapper/values.yaml
@@ -4,6 +4,7 @@
 service:
   name: "" # The name of the service, should be defined in the specific app-configs folder.
   hasHealthcheck: "true"
+  isResilient: "false"
 replicaCount: 2
 image:
   repository: coco/pac-annotations-mapper


### PR DESCRIPTION
- mappers aren't resilient: both pods read from kafka using the same consumer group - this means only one of them is actually receiving the messages; if the pod which isn't receiving the messages stops, that's not problem, but if the pod who is actually receiving the messages stops working, then the other pod will not pick up messages either
- by marking it as non-resilient, the upp-aggregate-healthcheck (any versions which include this [PR](https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/22)) will report the highest severity of any failed pods as the severity for the service 
- reduced the severity from 1 to 2 so any failures in this service will not turn dashing red