### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,10 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - PAC Annotations Mapper
 
 Processes content annotations into UPP from TagMe via PAC.
 
+## Code
+
+pac-annotations-mapper
+
 ## Primary URL
 
-<https://upp-prod-delivery-glb.upp.ft.com/__pac-annotations-mapper/>
+https://upp-prod-delivery-glb.upp.ft.com/__pac-annotations-mapper/
 
 ## Service Tier
 
@@ -14,27 +22,6 @@ Platinum
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- miroslav.gatsanoga
-- ivan.nikolov
-- marina.chompalova
-- mihail.mihaylov
-- boyko.boykov
-- donislav.belev
-- dimitar.terziev
-
-
 ## Host Platform
 
 AWS
@@ -43,10 +30,10 @@ AWS
 
 Mapper for transforming PAC annotations to UPP annotations:
 
-- Reads PAC metadata for an article from the Kafka topic *NativeCmsMetadataPublicationEvents*
-- Metadata for sources different than `http://cmdb.ft.com/systems/pac` is skipped by this mapper
-- Filters and transforms it to UPP standard JSON representation
-- Writes the result onto the Kafka topic *ConceptAnnotations*
+*   Reads PAC metadata for an article from the Kafka topic _NativeCmsMetadataPublicationEvents_
+*   Metadata for sources different than `http://cmdb.ft.com/systems/pac` is skipped by this mapper
+*   Filters and transforms it to UPP standard JSON representation
+*   Writes the result onto the Kafka topic _ConceptAnnotations_
 
 This service has NO service endpoints.
 
@@ -58,9 +45,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- upp-kafka
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -99,6 +96,14 @@ Manual
 
 Manual failover is not needed when a new version of the service is deployed to production.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -112,8 +117,8 @@ To rotate credentials you need to login to a particular cluster and update varni
 
 Service in UPP K8S delivery clusters:
 
-- Delivery-Prod-EU health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=pac-annotations-mapper>
-- Delivery-Prod-US health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=pac-annotations-mapper>
+*   Delivery-Prod-EU health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=pac-annotations-mapper>
+*   Delivery-Prod-US health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=pac-annotations-mapper>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/pac-annotations-mapper/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **pac-annotations-mapper** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **pac-annotations-mapper** system in [Biz Ops](https://biz-ops.in.ft.com/System/pac-annotations-mapper).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
